### PR TITLE
Add interactive content type to sport blocks

### DIFF
--- a/frontsapi/config/config.json
+++ b/frontsapi/config/config.json
@@ -13,7 +13,7 @@
                 "uk/technology/regular-stories",
                 "uk/money/regular-stories",
                 "uk/travel/regular-stories"
-                ]
+            ]
         },
 
         "us" : {
@@ -29,7 +29,7 @@
                 "us/technology/regular-stories",
                 "us/money/regular-stories",
                 "us/travel/regular-stories"
-                ]
+            ]
         },
 
         "au": {
@@ -46,7 +46,7 @@
                 "au/technology/regular-stories",
                 "au/money/regular-stories",
                 "au/travel/regular-stories"
-                ]
+            ]
         },
 
         "uk/sport" : {
@@ -366,7 +366,7 @@
 
         "uk/sport/regular-stories": {
             "roleName": "Top stories",
-            "apiQuery": "sport?tag=type/gallery|type/article|type/video|type/sudoku&show-editors-picks=true&edition=UK&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
+            "apiQuery": "sport?tag=type/gallery|type/article|type/video|type/sudoku|type/interactive&show-editors-picks=true&edition=UK&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
             "displayName": "Sport"
         },
         "uk/sport/feature-stories": {
@@ -375,7 +375,7 @@
         },
         "uk/football/regular-stories": {
             "roleName": "Section Stories",
-            "apiQuery": "football?tag=type/gallery|type/article|type/video|type/sudoku&show-editors-picks=true&edition=UK&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
+            "apiQuery": "football?tag=type/gallery|type/article|type/video|type/sudoku|type/interactive&show-editors-picks=true&edition=UK&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
             "displayName": "Football"
         },
         "uk/sport/cricket/regular-stories": {
@@ -503,7 +503,7 @@
 
         "us/sport/regular-stories": {
             "roleName": "Top stories",
-            "apiQuery": "sport?tag=type/gallery|type/article|type/video|type/sudoku&show-editors-picks=true&edition=US&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
+            "apiQuery": "sport?tag=type/gallery|type/article|type/video|type/sudoku|type/interactive&show-editors-picks=true&edition=US&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
             "displayName": "Sports"
         },
         "us/sport/feature-stories": {
@@ -610,7 +610,7 @@
 
         "au/sport/regular-stories": {
             "roleName": "Top stories",
-            "apiQuery": "sport?tag=type/gallery|type/article|type/video|type/sudoku&show-editors-picks=true&edition=AU&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
+            "apiQuery": "sport?tag=type/gallery|type/article|type/video|type/sudoku|type/interactive&show-editors-picks=true&edition=AU&show-fields=headline,trail-text,liveBloggingNow,thumbnail,hasStoryPackage,wordcount,shortUrl&show-elements=all",
             "displayName": "Sport"
         },
         "au/sport/feature-stories": {


### PR DESCRIPTION
Editorial would like the new world cup interactive to show on network fronts and sport pages. 

This enables that.

http://www.theguardian.com/football/ng-interactive/2013/dec/world-cup-draw-2014-create-your-own-draw-interactive?seed=VaMAdq

n.b.
We should do some further thinking how we can filter the interactive by ones we support from the rest.
