### PR TITLE
Reverse the group order

### DIFF
--- a/frontsapi/config/config.json
+++ b/frontsapi/config/config.json
@@ -327,7 +327,7 @@
         },
         "uk-alpha/special/special-story": {
             "roleName": "Special",
-            "groups": ["other content", "main content", "lead content"],
+            "groups": ["lead content", "main content", "other content"],
             "tone": "news"
         },
         "uk-alpha/contributors/feature-stories": {
@@ -356,7 +356,7 @@
         },
         "us-alpha/special/special-story": {
             "roleName": "Special",
-            "groups": ["other content", "main content", "lead content"],
+            "groups": ["lead content", "main content", "other content"],
             "tone": "news"
         },
         "us-alpha/contributors/feature-stories": {
@@ -385,7 +385,7 @@
         },
         "au-alpha/special/special-story": {
             "roleName": "Special",
-            "groups": ["other content", "main content", "lead content"],
+            "groups": ["lead content", "main content", "other content"],
             "tone": "news"
         },
         "au-alpha/contributors/feature-stories": {


### PR DESCRIPTION
@stephanfowler 

I have reversed the group order to be more logical. When writing to CAPI, this order is wrong, unless I did a reverse.
